### PR TITLE
Add yacht types to mobile menu

### DIFF
--- a/data/ust.php
+++ b/data/ust.php
@@ -102,7 +102,27 @@
 									<?php
 								}
 							}
-							?>
+<?php
+// Query to list yacht types that have active yachts
+$yachtTypes=$VT->VeriGetir("yacht_types \
+    INNER JOIN yachts ON yacht_types.id = yachts.type_id",
+    "WHERE yacht_types.durum=? AND yachts.is_active=?",
+    array(1, 1),
+    "GROUP BY yacht_types.id ORDER BY yacht_types.sirano ASC");
+
+if($yachtTypes!=false)
+{
+    for ($i=0; $i <count($yachtTypes); $i++) {
+        ?>
+<li class="luxury-submenu-item">
+    <a class="luxury-submenu-link" href="<?=SITE?>yacht-type/<?=$yachtTypes[$i]["seflink"]?>">
+        <span class="submenu-diamond"></span>
+        <?=stripslashes($yachtTypes[$i]["title"])?></a>
+</li>
+        <?php
+    }
+}
+?>
 						</ul>
 					</li>
 					


### PR DESCRIPTION
## Summary
- extend mobile "Yachts" navigation to include yacht types with links to listing pages

## Testing
- `php -l data/ust.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849840c32f4832a9918334237f4df15